### PR TITLE
Add GetClientSentiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ func main() {
                 fmt.Println("CloseLevel:", transaction.CloseLevel)
                 fmt.Println("Profit/Loss:", transaction.ProfitAndLoss)
 	}
+
+        // Example of getting client sentiment
+        sentiment, _ := ig.GetClientSentiment("F-US") //Ford
+        fmt.Println("Sentiment example:", sentiment)
 }
 ```
 

--- a/igmarkets.go
+++ b/igmarkets.go
@@ -291,7 +291,7 @@ type Snapshot struct {
 	ControlledRiskExtraSpread float64 `json:"controlledRiskExtraSpread"`
 }
 
-// MarketsResponse - Marekt response for /markets/{epic}
+// MarketsResponse - Market response for /markets/{epic}
 type MarketsResponse struct {
 	DealingRules DealingRules `json:"dealingRules"`
 	Instrument   Instrument   `json:"instrument"`
@@ -345,6 +345,12 @@ type Price struct {
 	Bid        float64 `json:"bid"`
 	Ask        float64 `json:"ask"`
 	LastTraded float64 `json:"lastTraded"` // Last traded price
+}
+
+// ClientSentimentResponse - Response for client sentiment
+type ClientSentimentResponse struct {
+	LongPositionPercentage  float64 `json:"longPositionPercentage"`
+	ShortPositionPercentage float64 `json:"shortPositionPercentage"`
 }
 
 const (
@@ -697,6 +703,21 @@ func (ig *IGMarkets) GetMarkets(epic string) (*MarketsResponse, error) {
 
 	igResponseInterface, err := ig.doRequest(req, 3, MarketsResponse{})
 	igResponse, _ := igResponseInterface.(*MarketsResponse)
+
+	return igResponse, err
+}
+
+// GetClientSentiment - Get the client sentiment for the given instrument's market
+func (ig *IGMarkets) GetClientSentiment(MarketID string) (*ClientSentimentResponse, error) {
+	bodyReq := new(bytes.Buffer)
+
+	req, err := http.NewRequest("GET", ig.APIURL+"/gateway/deal/clientsentiment/"+MarketID, bodyReq)
+	if err != nil {
+		return &ClientSentimentResponse{}, fmt.Errorf("igmarkets: unable to create HTTP request for GetClientSentiment: %v", err)
+	}
+
+	igResponseInterface, err := ig.doRequest(req, 1, ClientSentimentResponse{})
+	igResponse, _ := igResponseInterface.(*ClientSentimentResponse)
 
 	return igResponse, err
 }


### PR DESCRIPTION
**Description**

This adds a GetClientSentiment call which implements another of IG's endpoints.

**Notes**

The input to it is a marketID, it took me a while to figure out what this was. To get it you need to do a "market search", then you have to look up that market with /market/{epicId} and it is contained in that output. It might be useful to make this method just accept an epicId and do the lookup programmatically if you think that's an idea I'll do it.